### PR TITLE
Update service_model_serializers.py

### DIFF
--- a/service/serializers/service_model_serializers.py
+++ b/service/serializers/service_model_serializers.py
@@ -10,7 +10,7 @@ class ServiceListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Service
-        fields = ["id", "title", "primary_image"]
+        fields = ["id", "title", "primary_image", "secondary_image"]  # Added secondary_image here
 
 
 class AdminServiceDetailSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
# Fix: Add secondary_image field to service list API response

## 🐛 Problem Description

The service list API was not returning the `secondary_image` field in the response, even though the field exists in the Service model. This caused the secondary images to be missing from the frontend service listings.

**Related Issue:** Fixes #4 - Bug: secondary_image not showing in service list

## 🔧 Solution

Updated the `ServiceListSerializer` in `service/serializers/service_model_serializers.py` to include the `secondary_image` field in the serialized output.

### Changes Made

**File:** `service/serializers/service_model_serializers.py`
**Line:** 14

**Before:**
```python
class ServiceListSerializer(serializers.ModelSerializer):
    """For listing services (lightweight)."""

    class Meta:
        model = Service
        fields = ["id", "title", "primary_image"]

```
**After:**
```python
class ServiceListSerializer(serializers.ModelSerializer):
    """For listing services (lightweight)."""

    class Meta:
        model = Service
        fields = ["id", "title", "primary_image", "secondary_image"]